### PR TITLE
問題ページにテキストエリアを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ignore
 node_modules
 dist
+.vscode

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Yoshinori Kosaka <yoshinori.kosaka@welyco.com>",
   "license": "MIT",
   "dependencies": {
+    "@webcomponents/custom-elements": "^1.4.1",
     "lit-element": "^2.3.1",
     "webextension-polyfill-ts": "^0.16.0"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,6 +17,9 @@
     "scripts": ["background.js"],
     "persistent": false
   },
+  "content_scripts": [
+    { "matches": ["https://atcoder.jp/*"], "js": ["content_scripts.js"] }
+  ],
   "icons": {
     "16": "images/get_started16.png",
     "32": "images/get_started32.png",

--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -6,19 +6,26 @@ export class NoteEditor extends LitElement {
 
   static get styles() {
     return css`
+      .atcoder-note-editor-area {
+        width: 100%;
+        box-sizing: border-box;
+      }
+
       .atcoder-note-editor {
+        width: 100%;
+        border: 1px solid #ccc;
+        border-radius: 3px;
         padding: 8px;
-        margin: 8px 0;
-        border: 1px solid #aaa;
-        border-radius: 6px;
+        box-sizing: border-box;
+        resize: vertical;
       }
     `;
   }
 
   render() {
     return html`
-      <div class="atcoder-note-editor">
-        <textarea value="${this.text}"></textarea>
+      <div class="atcoder-note-editor-area">
+        <textarea class="atcoder-note-editor" value="${this.text}"></textarea>
       </div>
     `;
   }

--- a/src/content_scripts.ts
+++ b/src/content_scripts.ts
@@ -1,7 +1,19 @@
 // import { browser } from "webextension-polyfill-ts";
+import "@webcomponents/custom-elements";
+import "./components/editor";
 
 const execute = async () => {
-  console.log("hello, world");
+  const path = window.location.pathname;
+  const data = path.match(/\/contests\/(.+)\/tasks\/(.+)/);
+  if (data) {
+    const taskStatement = document.getElementById("task-statement");
+    if (taskStatement == null) {
+      return;
+    }
+
+    const el = document.createElement("atcoder-note-editor");
+    taskStatement.parentNode?.insertBefore(el, taskStatement.nextSibling);
+  }
 };
 
 execute();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": [
+      "DOM"
+    ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webcomponents/custom-elements@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.4.1.tgz#9803aaa2286a13a4ba200a7a2ea767871598eb60"
+  integrity sha512-vNCS1+3sxJOpoIsBjUQiXjGLngakEAGOD5Ale+6ikg6OZG5qI5O39frm3raPhud/IwnF4vec5ags05YBsgzcuA==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
# 目的

- content-scriptで、webcomponentを読み込めるようにした
- テキストエリアを問題ページに表示

# 次以降でやること

- テキストのセーブ

# スクリーンショット

<img width="873" alt="スクリーンショット 2020-05-31 11 26 53" src="https://user-images.githubusercontent.com/36811303/83343185-fa858200-a331-11ea-88f6-9e28ffb37ccf.png">
